### PR TITLE
Implement flip tile services section

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,58 @@
       text-decoration: none;
       margin-top: 1rem;
     }
+    .services-section {
+      padding: 2rem 0;
+    }
+    .service-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 1rem;
+    }
+    @media (min-width: 600px) {
+      .service-grid {
+        grid-template-columns: repeat(2, 1fr);
+      }
+    }
+    @media (min-width: 900px) {
+      .service-grid {
+        grid-template-columns: repeat(4, 1fr); /* AI: show all tiles in a single row */
+      }
+    }
+    .flip-card {
+      perspective: 1000px;
+    }
+    .flip-inner {
+      position: relative;
+      width: 100%;
+      padding-top: 100%;
+      transition: transform 0.6s;
+      transform-style: preserve-3d;
+    }
+    .flip-card:hover .flip-inner,
+    .flip-card.flip .flip-inner {
+      transform: rotateY(180deg);
+    }
+    .flip-front, .flip-back {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: #f0f0f0;
+      border-radius: 8px;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      padding: 1rem;
+      backface-visibility: hidden;
+    }
+    .flip-back {
+      transform: rotateY(180deg);
+    }
+
   </style>
 </head>
 <body>
@@ -91,7 +143,62 @@
         </div>
       </section>
 
-      <section id="services" class="services-section">
-        <h3>Our Services</h3>
-        <
+<section id="services" class="services-section"><!-- AI: Service flip tiles added -->
+  <h3>Our Services</h3>
+  <div class="service-grid">
+    <article class="flip-card">
+      <div class="flip-inner">
+        <div class="flip-front">
+          <h4>AI Strategy &amp; Roadmapping</h4>
+        </div>
+        <div class="flip-back">
+          <p>We help you map out where AI fits into your business — responsibly, practically, and with long-term value.</p>
+        </div>
+      </div>
+    </article>
+    <article class="flip-card">
+      <div class="flip-inner">
+        <div class="flip-front">
+          <h4>Automation Audits</h4>
+        </div>
+        <div class="flip-back">
+          <p>We assess where time and money are being wasted — then help you streamline with smart automation.</p>
+        </div>
+      </div>
+    </article>
+    <article class="flip-card">
+      <div class="flip-inner">
+        <div class="flip-front">
+          <h4>Tool Setup &amp; Support</h4>
+        </div>
+        <div class="flip-back">
+          <p>From GPTs to full-stack tools, we help you implement and manage AI tech that works for your needs.</p>
+        </div>
+      </div>
+    </article>
+    <article class="flip-card">
+      <div class="flip-inner">
+        <div class="flip-front">
+          <h4>Ethical AI Consulting</h4>
+        </div>
+        <div class="flip-back">
+          <p>We advise on AI use that’s transparent, inclusive, and aligned with UK business values and data ethics.</p>
+        </div>
+      </div>
+    </article>
+  </div>
+</section>
 
+</main>
+
+<script>
+  document.querySelectorAll('.flip-card').forEach(card => {
+    card.addEventListener('click', () => {
+      card.classList.toggle('flip');
+    });
+  });
+</script>
+
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- complete `index.html` with closing tags
- add responsive flip tile styles
- create `Our Services` section with four flip tiles
- enable flip-on-click for mobile
- tweak grid to show all tiles in a single row on large screens

## Testing
- `tidy -errors -q index.html`


------
https://chatgpt.com/codex/tasks/task_e_687421fccd24832a822349b4031018be