### PR TITLE
Update navigation with dropdown tiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,22 +26,12 @@
       position: relative;
     }
     .app-menu-btn {
-      background: none;
-      border: none;
+      background: #e5e5e5;
+      border: 1px solid transparent;
+      border-radius: 4px;
       cursor: pointer;
-      padding: 0.5rem;
-    }
-    .icon-grid {
-      display: grid;
-      grid-template-columns: repeat(3, 4px);
-      gap: 2px;
-    }
-    .icon-grid span {
-      width: 4px;
-      height: 4px;
-      background: #333;
-      border-radius: 1px;
-      display: block;
+      padding: 0.5rem 0.75rem;
+      font-size: 0.875rem;
     }
     .app-menu-dropdown {
       display: none;
@@ -182,21 +172,15 @@
     <header id="site-header">
       <h1 class="site-title">SereneAI</h1>
       <div class="app-menu" id="app-menu">
-        <button id="app-menu-btn" class="app-menu-btn" aria-label="Open site menu" aria-haspopup="true" aria-expanded="false">
-          <span class="icon-grid" aria-hidden="true">
-            <span></span><span></span><span></span>
-            <span></span><span></span><span></span>
-            <span></span><span></span><span></span>
-          </span>
-        </button>
+        <button id="app-menu-btn" class="app-menu-btn" aria-label="Open site menu" aria-haspopup="true" aria-expanded="false">Navigation</button>
         <nav class="app-menu-dropdown" aria-label="Site">
           <div class="app-grid">
-            <a href="index.html" class="app-tile">Home</a>
-            <a href="about.html" class="app-tile">About</a>
-            <a href="services.html" class="app-tile">Services</a>
-            <a href="prompt-library.html" class="app-tile">Prompt Library</a>
-            <a href="gpts.html" class="app-tile">GPT Tools</a>
-            <a href="community.html" class="app-tile">Community</a>
+            <a href="index.html" class="app-tile">🏠 Home</a>
+            <a href="about.html" class="app-tile">ℹ️ About</a>
+            <a href="services.html" class="app-tile">🛠️ Services</a>
+            <a href="prompt-library.html" class="app-tile">🧠 Prompt Library</a>
+            <a href="gpts.html" class="app-tile">🤖 GPT Tools</a>
+            <a href="community.html" class="app-tile">🧑‍🤝‍🧑 Community</a>
           </div>
         </nav>
       </div>


### PR DESCRIPTION
## Summary
- convert header navigation icon into a text button
- show dropdown of emoji tiles for site pages
- style button and remove icon grid

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687429bc7968832a86e08c7a3005f2ba