### PR TITLE
Add cookie banner and ARIA labels

### DIFF
--- a/community.html
+++ b/community.html
@@ -96,6 +96,20 @@
       text-decoration: none;
       margin-top: 1rem;
     }
+    .cookie-banner {
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      background: #fff;
+      box-shadow: 0 -2px 6px rgba(0,0,0,0.15);
+      padding: 1rem;
+      display: none;
+      z-index: 300;
+    }
+    .cookie-banner[aria-hidden="false"] {
+      display: block;
+    }
   </style>
 </head>
 <body>
@@ -123,13 +137,13 @@
         <p class="intro">Connect with like-minded people across the UK. Choose the space that suits you best.</p>
         <div class="community-grid">
           <div class="community-tile">
-            <div class="icon">🔗</div>
+            <div class="icon" role="img" aria-label="LinkedIn icon">🔗</div>
             <h3>LinkedIn Community</h3>
             <p>Your place to find like-minded UK people.</p>
             <a class="cta-button" href="#">Join on LinkedIn</a>
           </div>
           <div class="community-tile">
-            <div class="icon">💬</div>
+            <div class="icon" role="img" aria-label="Teams icon">💬</div>
             <h3>Teams Community</h3>
             <p>Your free place for support and community.</p>
             <a class="cta-button" href="#">Join on Teams</a>
@@ -139,6 +153,11 @@
     </main>
 
     <!-- Footer intentionally matches home page (currently empty) -->
+
+    <div id="cookie-banner" class="cookie-banner" role="dialog" aria-hidden="true" aria-label="Cookie consent">
+      <span>This site uses cookies to enhance your experience.</span>
+      <button id="accept-cookies" class="btn-primary" type="button">Accept</button>
+    </div>
 
     <script>
       const appMenu = document.getElementById('app-menu');
@@ -154,6 +173,19 @@
           appMenuBtn.setAttribute('aria-expanded', 'false');
         }
       });
+
+      // AI: cookie banner logic
+      (function() {
+        const banner = document.getElementById('cookie-banner');
+        const accept = document.getElementById('accept-cookies');
+        if (!localStorage.getItem('cookies-accepted')) {
+          banner.setAttribute('aria-hidden', 'false');
+        }
+        accept.addEventListener('click', () => {
+          localStorage.setItem('cookies-accepted', 'true');
+          banner.setAttribute('aria-hidden', 'true');
+        });
+      })();
     </script>
   </div>
 </body>

--- a/gpts.html
+++ b/gpts.html
@@ -133,6 +133,20 @@
       text-decoration: none;
       margin-top: 1rem;
     }
+    .cookie-banner {
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      background: #fff;
+      box-shadow: 0 -2px 6px rgba(0,0,0,0.15);
+      padding: 1rem;
+      display: none;
+      z-index: 300;
+    }
+    .cookie-banner[aria-hidden="false"] {
+      display: block;
+    }
   </style>
 </head>
 <body>
@@ -177,6 +191,11 @@
 
     <!-- Footer intentionally matches home page (currently empty) -->
 
+    <div id="cookie-banner" class="cookie-banner" role="dialog" aria-hidden="true" aria-label="Cookie consent">
+      <span>This site uses cookies to enhance your experience.</span>
+      <button id="accept-cookies" class="btn-primary" type="button">Accept</button>
+    </div>
+
     <script>
       document.querySelectorAll('.flip-card').forEach(card => {
         card.addEventListener('click', () => {
@@ -196,6 +215,19 @@
           appMenuBtn.setAttribute('aria-expanded', 'false');
         }
       });
+
+      // AI: cookie banner logic
+      (function() {
+        const banner = document.getElementById('cookie-banner');
+        const accept = document.getElementById('accept-cookies');
+        if (!localStorage.getItem('cookies-accepted')) {
+          banner.setAttribute('aria-hidden', 'false');
+        }
+        accept.addEventListener('click', () => {
+          localStorage.setItem('cookies-accepted', 'true');
+          banner.setAttribute('aria-hidden', 'true');
+        });
+      })();
     </script>
   </div>
 </body>

--- a/index.html
+++ b/index.html
@@ -112,6 +112,20 @@
     .btn-secondary:hover {
       background: #d5d5d5;
     }
+    .cookie-banner {
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      background: #fff;
+      box-shadow: 0 -2px 6px rgba(0,0,0,0.15);
+      padding: 1rem;
+      display: none;
+      z-index: 300;
+    }
+    .cookie-banner[aria-hidden="false"] {
+      display: block;
+    }
     .cta-button {
       display: inline-block;
       background: #0a84ff;
@@ -363,6 +377,11 @@
       </div>
     </div>
 
+    <div id="cookie-banner" class="cookie-banner" role="dialog" aria-hidden="true" aria-label="Cookie consent">
+      <span>This site uses cookies to enhance your experience.</span>
+      <button id="accept-cookies" class="btn-primary" type="button">Accept</button>
+    </div>
+
 <script>
   // REVIEW: consider moving scripts to an external file
   document.querySelectorAll('.flip-card').forEach(card => {
@@ -451,6 +470,19 @@
 
   setupModal('contact-modal', 'open-modal');
   setupModal('newsletter-modal', 'open-newsletter'); // AI: newsletter setup
+
+  // AI: cookie banner logic
+  (function() {
+    const banner = document.getElementById('cookie-banner');
+    const accept = document.getElementById('accept-cookies');
+    if (!localStorage.getItem('cookies-accepted')) {
+      banner.setAttribute('aria-hidden', 'false');
+    }
+    accept.addEventListener('click', () => {
+      localStorage.setItem('cookies-accepted', 'true');
+      banner.setAttribute('aria-hidden', 'true');
+    });
+  })();
 </script>
 
   </div>

--- a/prompt-library.html
+++ b/prompt-library.html
@@ -126,6 +126,20 @@
       padding: 0.5rem 1rem;
       cursor: pointer;
     }
+    .cookie-banner {
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      background: #fff;
+      box-shadow: 0 -2px 6px rgba(0,0,0,0.15);
+      padding: 1rem;
+      display: none;
+      z-index: 300;
+    }
+    .cookie-banner[aria-hidden="false"] {
+      display: block;
+    }
   </style>
 </head>
 <body>
@@ -206,6 +220,11 @@
 
     <!-- Footer intentionally matches home page (currently empty) -->
 
+    <div id="cookie-banner" class="cookie-banner" role="dialog" aria-hidden="true" aria-label="Cookie consent">
+      <span>This site uses cookies to enhance your experience.</span>
+      <button id="accept-cookies" class="btn-primary" type="button">Accept</button>
+    </div>
+
     <script>
       const appMenu = document.getElementById('app-menu');
       const appMenuBtn = document.getElementById('app-menu-btn');
@@ -220,6 +239,19 @@
           appMenuBtn.setAttribute('aria-expanded', 'false');
         }
       });
+
+      // AI: cookie banner logic
+      (function() {
+        const banner = document.getElementById('cookie-banner');
+        const accept = document.getElementById('accept-cookies');
+        if (!localStorage.getItem('cookies-accepted')) {
+          banner.setAttribute('aria-hidden', 'false');
+        }
+        accept.addEventListener('click', () => {
+          localStorage.setItem('cookies-accepted', 'true');
+          banner.setAttribute('aria-hidden', 'true');
+        });
+      })();
     </script>
   </div>
 </body>


### PR DESCRIPTION
## Summary
- add alt text to community icons
- introduce cookie banner across pages
- implement banner visibility logic with localStorage

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68743d583244832a9db6f6099fca6422