### PR TITLE
Fix mobile modal scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -199,6 +199,7 @@
       justify-content: center;
       background: rgba(0,0,0,0.5);
       z-index: 200;
+      overflow-y: auto; /* AI: allow modal scrolling on mobile */
     }
     .modal[aria-hidden="false"] {
       display: flex;
@@ -211,6 +212,8 @@
       max-width: 500px;
       padding: 1.5rem;
       position: relative;
+      max-height: 90vh; /* AI: prevent content cut-off */
+      overflow-y: auto; /* AI: enable scrolling within the form */
     }
     .modal-close {
       position: absolute;


### PR DESCRIPTION
## Summary
- allow modal content to scroll
- prevent modal forms from exceeding viewport height on small screens

## Testing
- `tidy -q -e index.html`
- `tidy -q -e community.html`
- `tidy -q -e prompt-library.html`
- `tidy -q -e gpts.html`


------
https://chatgpt.com/codex/tasks/task_e_68743f3bf7d4832a9d3b86a1236151c0