### PR TITLE
Add GDPR cookie banner

### DIFF
--- a/community.html
+++ b/community.html
@@ -97,20 +97,6 @@
       text-decoration: none;
       margin-top: 1rem;
     }
-    .cookie-banner {
-      position: fixed;
-      bottom: 0;
-      left: 0;
-      right: 0;
-      background: #fff;
-      box-shadow: 0 -2px 6px rgba(0,0,0,0.15);
-      padding: 1rem;
-      display: none;
-      z-index: 300;
-    }
-    .cookie-banner[aria-hidden="false"] {
-      display: block;
-    }
   </style>
 </head>
 <body>
@@ -155,9 +141,11 @@
 
     <!-- Footer intentionally matches home page (currently empty) -->
 
-    <div id="cookie-banner" class="cookie-banner" role="dialog" aria-hidden="true" aria-label="Cookie consent">
-      <span>This site uses cookies to enhance your experience.</span>
-      <button id="accept-cookies" class="btn-primary" type="button">Accept</button>
+    <!-- Begin Cookie Banner -->
+    <div id="cookie-banner" role="dialog" aria-label="Cookie consent" aria-hidden="true" aria-live="polite"
+      style="position:fixed;bottom:0;left:0;right:0;z-index:300;background:#f0f4f8;color:#002b5c;padding:.75rem 1rem;font-size:.875rem;box-shadow:0 -2px 6px rgba(0,0,0,0.15);display:none;flex-wrap:wrap;align-items:center;">
+      <span>This site uses cookies to enhance your experience. <a href="/SereneAI-Full-Build/privacy.html" style="color:#002b5c;text-decoration:underline;">Learn more</a></span>
+      <button id="accept-cookies" type="button" style="margin-left:auto;background:#002b5c;color:#fff;border:none;border-radius:4px;padding:0.5rem 1rem;font-size:.875rem;cursor:pointer;">Accept</button>
     </div>
 
     <script>
@@ -177,14 +165,24 @@
 
       // AI: cookie banner logic
       (function() {
+        const consentKey = 'sa_cookie_consent';
         const banner = document.getElementById('cookie-banner');
         const accept = document.getElementById('accept-cookies');
-        if (!localStorage.getItem('cookies-accepted')) {
+        if (!localStorage.getItem(consentKey)) {
+          banner.style.display = 'flex';
           banner.setAttribute('aria-hidden', 'false');
         }
-        accept.addEventListener('click', () => {
-          localStorage.setItem('cookies-accepted', 'true');
+        function handleAccept() {
+          localStorage.setItem(consentKey, 'true');
           banner.setAttribute('aria-hidden', 'true');
+          banner.style.display = 'none';
+        }
+        accept.addEventListener('click', handleAccept);
+        accept.addEventListener('keydown', e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleAccept();
+          }
         });
       })();
     </script>

--- a/gpts.html
+++ b/gpts.html
@@ -134,20 +134,6 @@
       text-decoration: none;
       margin-top: 1rem;
     }
-    .cookie-banner {
-      position: fixed;
-      bottom: 0;
-      left: 0;
-      right: 0;
-      background: #fff;
-      box-shadow: 0 -2px 6px rgba(0,0,0,0.15);
-      padding: 1rem;
-      display: none;
-      z-index: 300;
-    }
-    .cookie-banner[aria-hidden="false"] {
-      display: block;
-    }
   </style>
 </head>
 <body>
@@ -192,9 +178,11 @@
 
     <!-- Footer intentionally matches home page (currently empty) -->
 
-    <div id="cookie-banner" class="cookie-banner" role="dialog" aria-hidden="true" aria-label="Cookie consent">
-      <span>This site uses cookies to enhance your experience.</span>
-      <button id="accept-cookies" class="btn-primary" type="button">Accept</button>
+    <!-- Begin Cookie Banner -->
+    <div id="cookie-banner" role="dialog" aria-label="Cookie consent" aria-hidden="true" aria-live="polite"
+      style="position:fixed;bottom:0;left:0;right:0;z-index:300;background:#f0f4f8;color:#002b5c;padding:.75rem 1rem;font-size:.875rem;box-shadow:0 -2px 6px rgba(0,0,0,0.15);display:none;flex-wrap:wrap;align-items:center;">
+      <span>This site uses cookies to enhance your experience. <a href="/SereneAI-Full-Build/privacy.html" style="color:#002b5c;text-decoration:underline;">Learn more</a></span>
+      <button id="accept-cookies" type="button" style="margin-left:auto;background:#002b5c;color:#fff;border:none;border-radius:4px;padding:0.5rem 1rem;font-size:.875rem;cursor:pointer;">Accept</button>
     </div>
 
     <script>
@@ -219,14 +207,24 @@
 
       // AI: cookie banner logic
       (function() {
+        const consentKey = 'sa_cookie_consent';
         const banner = document.getElementById('cookie-banner');
         const accept = document.getElementById('accept-cookies');
-        if (!localStorage.getItem('cookies-accepted')) {
+        if (!localStorage.getItem(consentKey)) {
+          banner.style.display = 'flex';
           banner.setAttribute('aria-hidden', 'false');
         }
-        accept.addEventListener('click', () => {
-          localStorage.setItem('cookies-accepted', 'true');
+        function handleAccept() {
+          localStorage.setItem(consentKey, 'true');
           banner.setAttribute('aria-hidden', 'true');
+          banner.style.display = 'none';
+        }
+        accept.addEventListener('click', handleAccept);
+        accept.addEventListener('keydown', e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleAccept();
+          }
         });
       })();
     </script>

--- a/index.html
+++ b/index.html
@@ -113,20 +113,6 @@
     .btn-secondary:hover {
       background: #d5d5d5;
     }
-    .cookie-banner {
-      position: fixed;
-      bottom: 0;
-      left: 0;
-      right: 0;
-      background: #fff;
-      box-shadow: 0 -2px 6px rgba(0,0,0,0.15);
-      padding: 1rem;
-      display: none;
-      z-index: 300;
-    }
-    .cookie-banner[aria-hidden="false"] {
-      display: block;
-    }
     .cta-button {
       display: inline-block;
       background: #0a84ff;
@@ -381,9 +367,11 @@
       </div>
     </div>
 
-    <div id="cookie-banner" class="cookie-banner" role="dialog" aria-hidden="true" aria-label="Cookie consent">
-      <span>This site uses cookies to enhance your experience.</span>
-      <button id="accept-cookies" class="btn-primary" type="button">Accept</button>
+    <!-- Begin Cookie Banner -->
+    <div id="cookie-banner" role="dialog" aria-label="Cookie consent" aria-hidden="true" aria-live="polite"
+      style="position:fixed;bottom:0;left:0;right:0;z-index:300;background:#f0f4f8;color:#002b5c;padding:.75rem 1rem;font-size:.875rem;box-shadow:0 -2px 6px rgba(0,0,0,0.15);display:none;flex-wrap:wrap;align-items:center;">
+      <span>This site uses cookies to enhance your experience. <a href="/SereneAI-Full-Build/privacy.html" style="color:#002b5c;text-decoration:underline;">Learn more</a></span>
+      <button id="accept-cookies" type="button" style="margin-left:auto;background:#002b5c;color:#fff;border:none;border-radius:4px;padding:0.5rem 1rem;font-size:.875rem;cursor:pointer;">Accept</button>
     </div>
 
 <script>
@@ -477,14 +465,24 @@
 
   // AI: cookie banner logic
   (function() {
+    const consentKey = 'sa_cookie_consent';
     const banner = document.getElementById('cookie-banner');
     const accept = document.getElementById('accept-cookies');
-    if (!localStorage.getItem('cookies-accepted')) {
+    if (!localStorage.getItem(consentKey)) {
+      banner.style.display = 'flex';
       banner.setAttribute('aria-hidden', 'false');
     }
-    accept.addEventListener('click', () => {
-      localStorage.setItem('cookies-accepted', 'true');
+    function handleAccept() {
+      localStorage.setItem(consentKey, 'true');
       banner.setAttribute('aria-hidden', 'true');
+      banner.style.display = 'none';
+    }
+    accept.addEventListener('click', handleAccept);
+    accept.addEventListener('keydown', e => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        handleAccept();
+      }
     });
   })();
 </script>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Privacy Policy - SereneAI</title>
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; margin:2rem; color:#333;">
+  <h1>Privacy Policy</h1>
+  <p>This is a placeholder privacy policy page for SereneAI.</p>
+</body>
+</html>

--- a/prompt-library.html
+++ b/prompt-library.html
@@ -127,20 +127,6 @@
       padding: 0.5rem 1rem;
       cursor: pointer;
     }
-    .cookie-banner {
-      position: fixed;
-      bottom: 0;
-      left: 0;
-      right: 0;
-      background: #fff;
-      box-shadow: 0 -2px 6px rgba(0,0,0,0.15);
-      padding: 1rem;
-      display: none;
-      z-index: 300;
-    }
-    .cookie-banner[aria-hidden="false"] {
-      display: block;
-    }
   </style>
 </head>
 <body>
@@ -221,9 +207,11 @@
 
     <!-- Footer intentionally matches home page (currently empty) -->
 
-    <div id="cookie-banner" class="cookie-banner" role="dialog" aria-hidden="true" aria-label="Cookie consent">
-      <span>This site uses cookies to enhance your experience.</span>
-      <button id="accept-cookies" class="btn-primary" type="button">Accept</button>
+    <!-- Begin Cookie Banner -->
+    <div id="cookie-banner" role="dialog" aria-label="Cookie consent" aria-hidden="true" aria-live="polite"
+      style="position:fixed;bottom:0;left:0;right:0;z-index:300;background:#f0f4f8;color:#002b5c;padding:.75rem 1rem;font-size:.875rem;box-shadow:0 -2px 6px rgba(0,0,0,0.15);display:none;flex-wrap:wrap;align-items:center;">
+      <span>This site uses cookies to enhance your experience. <a href="/SereneAI-Full-Build/privacy.html" style="color:#002b5c;text-decoration:underline;">Learn more</a></span>
+      <button id="accept-cookies" type="button" style="margin-left:auto;background:#002b5c;color:#fff;border:none;border-radius:4px;padding:0.5rem 1rem;font-size:.875rem;cursor:pointer;">Accept</button>
     </div>
 
     <script>
@@ -243,14 +231,24 @@
 
       // AI: cookie banner logic
       (function() {
+        const consentKey = 'sa_cookie_consent';
         const banner = document.getElementById('cookie-banner');
         const accept = document.getElementById('accept-cookies');
-        if (!localStorage.getItem('cookies-accepted')) {
+        if (!localStorage.getItem(consentKey)) {
+          banner.style.display = 'flex';
           banner.setAttribute('aria-hidden', 'false');
         }
-        accept.addEventListener('click', () => {
-          localStorage.setItem('cookies-accepted', 'true');
+        function handleAccept() {
+          localStorage.setItem(consentKey, 'true');
           banner.setAttribute('aria-hidden', 'true');
+          banner.style.display = 'none';
+        }
+        accept.addEventListener('click', handleAccept);
+        accept.addEventListener('keydown', e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleAccept();
+          }
         });
       })();
     </script>


### PR DESCRIPTION
## Summary
- integrate a persistent cookie banner across pages
- store consent under `sa_cookie_consent`
- create placeholder `privacy.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687444f6c1a4832aa665016fbdfd2267