### PR TITLE
Add Firebase sign-in/out tiles

### DIFF
--- a/auth/auth.js
+++ b/auth/auth.js
@@ -48,4 +48,24 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   }
+
+  // AI: global nav auth toggle
+  const signInLink = document.getElementById('nav-signin');
+  const signOutBtn = document.getElementById('nav-signout');
+  if (signInLink && signOutBtn && firebase?.auth) {
+    firebase.auth().onAuthStateChanged(user => {
+      const signedIn = !!user;
+      signInLink.style.display = signedIn ? 'none' : 'flex';
+      signOutBtn.style.display = signedIn ? 'flex' : 'none';
+    });
+
+    signOutBtn.addEventListener('click', async () => {
+      try {
+        await firebase.auth().signOut();
+      } catch (err) {
+        console.error(err);
+      }
+      window.location.href = '/';
+    });
+  }
 });

--- a/auth/login.html
+++ b/auth/login.html
@@ -45,6 +45,8 @@
             <a href="/prompt-library.html" class="app-tile">🧠 Prompt Library</a>
             <a href="/gpts.html" class="app-tile">🤖 GPT Tools</a>
             <a href="/community.html" class="app-tile">🧑‍🤝‍🧑 Community</a>
+            <a id="nav-signin" href="/auth/login.html" class="app-tile">🔐 Sign In</a>
+            <button id="nav-signout" type="button" class="app-tile" style="display:none">🚪 Sign Out</button>
           </div>
         </nav>
       </div>

--- a/auth/register.html
+++ b/auth/register.html
@@ -45,6 +45,8 @@
             <a href="/prompt-library.html" class="app-tile">🧠 Prompt Library</a>
             <a href="/gpts.html" class="app-tile">🤖 GPT Tools</a>
             <a href="/community.html" class="app-tile">🧑‍🤝‍🧑 Community</a>
+            <a id="nav-signin" href="/auth/login.html" class="app-tile">🔐 Sign In</a>
+            <button id="nav-signout" type="button" class="app-tile" style="display:none">🚪 Sign Out</button>
           </div>
         </nav>
       </div>

--- a/community.html
+++ b/community.html
@@ -98,6 +98,10 @@
       margin-top: 1rem;
     }
   </style>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js"></script>
+  <script src="/firebase-config.js"></script>
+  <script src="/auth/auth.js" defer></script>
 </head>
 <body>
   <div class="layout">
@@ -113,6 +117,8 @@
             <a href="prompt-library.html" class="app-tile">🧠 Prompt Library</a>
             <a href="gpts.html" class="app-tile">🤖 GPT Tools</a>
             <a href="community.html" class="app-tile">🧑‍🤝‍🧑 Community</a>
+            <a id="nav-signin" href="/auth/login.html" class="app-tile">🔐 Sign In</a>
+            <button id="nav-signout" type="button" class="app-tile" style="display:none">🚪 Sign Out</button>
           </div>
         </nav>
       </div>

--- a/gpts.html
+++ b/gpts.html
@@ -135,6 +135,10 @@
       margin-top: 1rem;
     }
   </style>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js"></script>
+  <script src="/firebase-config.js"></script>
+  <script src="/auth/auth.js" defer></script>
 </head>
 <body>
   <div class="layout">
@@ -150,6 +154,8 @@
             <a href="prompt-library.html" class="app-tile">🧠 Prompt Library</a>
             <a href="gpts.html" class="app-tile">🤖 GPT Tools</a>
             <a href="community.html" class="app-tile">🧑‍🤝‍🧑 Community</a>
+            <a id="nav-signin" href="/auth/login.html" class="app-tile">🔐 Sign In</a>
+            <button id="nav-signout" type="button" class="app-tile" style="display:none">🚪 Sign Out</button>
           </div>
         </nav>
       </div>

--- a/index.html
+++ b/index.html
@@ -230,11 +230,15 @@
       resize: vertical;
     }
 
-    .newsletter-modal .modal-dialog { /* AI: smaller modal for newsletter */
+  .newsletter-modal .modal-dialog { /* AI: smaller modal for newsletter */
       max-width: 350px;
     }
 
   </style>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js"></script>
+  <script src="/firebase-config.js"></script>
+  <script src="/auth/auth.js" defer></script>
 </head>
 <body>
   <div class="layout">
@@ -250,6 +254,8 @@
             <a href="prompt-library.html" class="app-tile">🧠 Prompt Library</a>
             <a href="gpts.html" class="app-tile">🤖 GPT Tools</a>
             <a href="community.html" class="app-tile">🧑‍🤝‍🧑 Community</a>
+            <a id="nav-signin" href="/auth/login.html" class="app-tile">🔐 Sign In</a>
+            <button id="nav-signout" type="button" class="app-tile" style="display:none">🚪 Sign Out</button>
           </div>
         </nav>
       </div>

--- a/prompt-library.html
+++ b/prompt-library.html
@@ -128,6 +128,10 @@
       cursor: pointer;
     }
   </style>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js"></script>
+  <script src="/firebase-config.js"></script>
+  <script src="/auth/auth.js" defer></script>
 </head>
 <body>
   <div class="layout">
@@ -143,6 +147,8 @@
             <a href="prompt-library.html" class="app-tile">🧠 Prompt Library</a>
             <a href="gpts.html" class="app-tile">🤖 GPT Tools</a>
             <a href="community.html" class="app-tile">🧑‍🤝‍🧑 Community</a>
+            <a id="nav-signin" href="/auth/login.html" class="app-tile">🔐 Sign In</a>
+            <button id="nav-signout" type="button" class="app-tile" style="display:none">🚪 Sign Out</button>
           </div>
         </nav>
       </div>


### PR DESCRIPTION
## Summary
- add Sign In/Out tiles to navigation hub
- load Firebase auth on all pages
- toggle nav items in `auth.js`

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68744dabf060832a94dd3db13ca32920