### PR TITLE
Restore login/register form listeners

### DIFF
--- a/auth/auth.js
+++ b/auth/auth.js
@@ -23,3 +23,48 @@ if (signInLink && signOutBtn && firebase?.auth) {
   });
 }
 
+// AI: attach auth form listeners
+document.addEventListener('DOMContentLoaded', () => {
+  const loginForm = document.getElementById('login-form');
+  const registerForm = document.getElementById('register-form');
+
+  if (loginForm) {
+    loginForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const email = document.getElementById('email').value.trim();
+      const password = document.getElementById('password').value;
+      try {
+        await firebase.auth().signInWithEmailAndPassword(email, password);
+        window.location.href = '/prompt-library.html';
+      } catch (err) {
+        alert(err.message);
+      }
+    });
+  }
+
+  if (registerForm) {
+    registerForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const name = document.getElementById('name').value.trim();
+      const email = document.getElementById('email').value.trim();
+      const password = document.getElementById('password').value;
+      const confirm = document.getElementById('confirmPassword').value;
+
+      if (password !== confirm) {
+        alert('Passwords do not match.');
+        return;
+      }
+
+      try {
+        const cred = await firebase.auth().createUserWithEmailAndPassword(email, password);
+        if (name && cred.user) {
+          await cred.user.updateProfile({ displayName: name });
+        }
+        window.location.href = '/prompt-library.html';
+      } catch (err) {
+        alert(err.message);
+      }
+    });
+  }
+});
+


### PR DESCRIPTION
## Summary
- reintroduce login and register event handlers in `auth/auth.js`
- keep existing navigation auth toggle logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68745301082c832a838d9cdbb9d30e36